### PR TITLE
Only run on staged files when using --staged

### DIFF
--- a/src/__tests__/scm-git.test.js
+++ b/src/__tests__/scm-git.test.js
@@ -25,7 +25,9 @@ const mockGitFs = () => {
       case 'ls-files':
         return { stdout: '' };
       case 'diff':
-        return { stdout: './foo.js\n' + './bar.md\n' };
+        return args[2] === '--cached'
+          ? { stdout: './foo.js\n' }
+          : { stdout: './foo.js\n' + './bar.md\n' };
       case 'add':
         return { stdout: '' };
       default:
@@ -149,7 +151,7 @@ describe('with git', () => {
     expect(fs.readFileSync('/bar.md', 'utf8')).toEqual('formatted:# foo');
   });
 
-  test('with --staged stages changed files', () => {
+  test('with --staged stages staged files', () => {
     mockGitFs();
 
     prettyQuick('root', { since: 'banana', staged: true });
@@ -157,7 +159,7 @@ describe('with git', () => {
     expect(execa.sync).toHaveBeenCalledWith('git', ['add', './foo.js'], {
       cwd: '/',
     });
-    expect(execa.sync).toHaveBeenCalledWith('git', ['add', './bar.md'], {
+    expect(execa.sync).not.toHaveBeenCalledWith('git', ['add', './bar.md'], {
       cwd: '/',
     });
   });

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ export default (
   onFoundSinceRevision && onFoundSinceRevision(scm.name, revision);
 
   const changedFiles = scm
-    .getChangedFiles(directory, revision)
+    .getChangedFiles(directory, revision, staged)
     .filter(isSupportedExtension)
     .filter(createIgnorer(directory));
 

--- a/src/scms/git.js
+++ b/src/scms/git.js
@@ -25,20 +25,23 @@ export const getSinceRevision = (directory, { staged }) => {
   return runGit(directory, ['rev-parse', '--short', revision]).stdout.trim();
 };
 
-export const getChangedFiles = (directory, revision) => {
-  return [
-    ...getLines(
-      runGit(directory, [
-        'diff',
-        '--name-only',
-        '--diff-filter=ACMRTUB',
-        revision,
-      ])
-    ),
-    ...getLines(
-      runGit(directory, ['ls-files', '--others', '--exclude-standard'])
-    ),
-  ].filter(Boolean);
+export const getChangedFiles = (directory, revision, staged) => {
+  return (staged
+    ? getLines(runGit(directory, ['diff', '--name-only', '--cached', revision]))
+    : [
+        ...getLines(
+          runGit(directory, [
+            'diff',
+            '--name-only',
+            '--diff-filter=ACMRTUB',
+            revision,
+          ])
+        ),
+        ...getLines(
+          runGit(directory, ['ls-files', '--others', '--exclude-standard'])
+        ),
+      ]
+  ).filter(Boolean);
 };
 
 export const stageFile = (directory, file) => {


### PR DESCRIPTION
Fixes #7

I had to add a `staged`-specific branch to `getChangedFiles` because just adding `--cached` to the `git diff` meant that any new files would also be returned from the `ls-files`.

For the tests, I just made a simple modification, although I was considering making the `mockGitFs` a bit more robust.