### PR TITLE
Configurable git branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ In `package.json`'s `"scripts"` section, add:
 
 Pre-commit mode. Under this flag only staged files will be formatted, and they will be re-staged after formatting.
 
+### `--branch`
+
+When in `staged` pre-commit mode, use this flag to compare changes with the specified branch. Defaults to `master` branch.
+
 <!-- Undocumented = Unsupported :D
 
 ### `--config`
@@ -89,4 +93,3 @@ For example `pretty-quick --since HEAD` will format only staged files.
 ## Configuration and Ignore Files
 
 `pretty-quick` will respect your [`.prettierrc`](https://prettier.io/docs/en/configuration) and [`.prettierignore`](https://prettier.io/docs/en/ignore#ignoring-files) files, so there's no additional setup required. Configuration files will be found by searching up the file system. `.prettierignore` files are only found from the working directory that the command was executed from.
-

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Pre-commit mode. Under this flag only staged files will be formatted, and they w
 
 ### `--branch`
 
-When in `staged` pre-commit mode, use this flag to compare changes with the specified branch. Defaults to `master` branch.
+When not in `staged` pre-commit mode, use this flag to compare changes with the specified branch. Defaults to `master` branch.
 
 <!-- Undocumented = Unsupported :D
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ export default (
     config,
     since,
     staged,
+    branch,
     onFoundSinceRevision,
     onFoundChangedFiles,
     onWriteFile,
@@ -20,7 +21,7 @@ export default (
   }
   const directory = scm.rootDirectory;
 
-  const revision = since || scm.getSinceRevision(directory, { staged });
+  const revision = since || scm.getSinceRevision(directory, { staged, branch });
 
   onFoundSinceRevision && onFoundSinceRevision(scm.name, revision);
 

--- a/src/scms/git.js
+++ b/src/scms/git.js
@@ -18,11 +18,15 @@ const runGit = (directory, args) =>
 
 const getLines = execaResult => execaResult.stdout.split('\n');
 
-export const getSinceRevision = (directory, { staged }) => {
+export const getSinceRevision = (directory, { staged, branch }) => {
   try {
     const revision = staged
       ? 'HEAD'
-      : runGit(directory, ['merge-base', 'HEAD', 'master']).stdout.trim();
+      : runGit(directory, [
+          'merge-base',
+          'HEAD',
+          branch || 'master',
+        ]).stdout.trim();
     return runGit(directory, ['rev-parse', '--short', revision]).stdout.trim();
   } catch (error) {
     if (


### PR DESCRIPTION
Defines a `--branch` switch so that user can specify a branch to use in merge-base other than `master`.  Defaults to `master` if not specified.