### PR TITLE
Add optional eslint --fix after prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ Partially staged files will not be re-staged after formatting and pretty-quick w
 
 When not in `staged` pre-commit mode, use this flag to compare changes with the specified branch. Defaults to `master` (git) / `default` (hg) branch.
 
+### `--eslintFix`
+
+Apply `eslint --fix` to `.js` and `.jsx` files after prittier.
+
 <!-- Undocumented = Unsupported :D
 
 ### `--config`

--- a/src/eslintLoader.js
+++ b/src/eslintLoader.js
@@ -1,0 +1,19 @@
+module.exports = function(filePath) {
+  try {
+    const CLIEngine = require('eslint').CLIEngine;
+    const cliEngineForConfig = new CLIEngine();
+    const config = Object.create(cliEngineForConfig.getConfigForFile(filePath));
+    config.fix = true;
+    const cliEngineForFix = new CLIEngine(config);
+    return {
+      eslintFixer: function(input) {
+        return (
+          cliEngineForFix.executeOnText(input, filePath, false).results[0]
+            .output || ''
+        );
+      },
+    };
+  } catch (e) {
+    throw new Error('Could not load eslint module.');
+  }
+};

--- a/src/formatFiles.js
+++ b/src/formatFiles.js
@@ -1,18 +1,26 @@
 import { readFileSync, writeFileSync } from 'fs';
 import { resolveConfig, format } from 'prettier';
-import { join } from 'path';
+import path, { join } from 'path';
 
-export default (directory, files, { config, onWriteFile } = {}) => {
+export default (directory, files, { config, eslintFix, onWriteFile } = {}) => {
+  const eslintExtensions = ['.js', '.jsx' /*, '.ts', '.tsx'*/];
+  const eslintCliEngine = eslintFix && require('./eslintLoader');
+
   for (const relative of files) {
     const file = join(directory, relative);
     const options = resolveConfig.sync(file, { config, editorconfig: true });
     const input = readFileSync(file, 'utf8');
-    const output = format(
+    const pritiffied = format(
       input,
       Object.assign({}, options, {
         filepath: file,
       })
     );
+    const output =
+      (eslintFix &&
+        eslintExtensions.includes(path.extname(file || '')) &&
+        eslintCliEngine(file).eslintFixer(pritiffied)) ||
+      pritiffied;
 
     if (output !== input) {
       writeFileSync(file, output);

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ export default (
   currentDirectory,
   {
     config,
+    eslintFix,
     since,
     staged,
     branch,
@@ -16,6 +17,16 @@ export default (
     onWriteFile,
   } = {}
 ) => {
+  if (eslintFix) {
+    try {
+      require.resolve('eslint');
+    } catch (e) {
+      throw new Error(
+        'Eslint should be installed in order to use --eslintFix.'
+      );
+    }
+  }
+
   const scm = scms(currentDirectory);
   if (!scm) {
     throw new Error('Unable to detect a source control manager.');
@@ -44,6 +55,7 @@ export default (
 
   formatFiles(directory, changedFiles, {
     config,
+    eslintFix,
     onWriteFile: file => {
       onWriteFile && onWriteFile(file);
       if (staged) {


### PR DESCRIPTION
This is my proposal to support optional eslint --fix on .js and .jsx files (would be possible .ts and .tsx as well) after applying prettier.
I've been looking for a solution, like prettier-eslint but supporting hooks (I don't find it entirely useful running it only manually) and I didn't find anything that meet my needs.

How to use:

> pretty-quick --eslintFix

_Note: adding --staged is how I find it more useful_

This implementation uses eslint CLIEngine API to get the eslint configuration on every js file, and the apply possible fixes. So simple, no messing options, it takes the current eslint config and goes on.
In my case, I love prettier and standard style guide, so I use prettier for every file and after that, just for js ones, I prefer to run the eslint fixer with standard configuration. This became the straightforward solution.

All current tests are passing after my modifications, but I had not enough time to write new ones.
This is a first commit, so if you consider it a useful improvement and its approach I'll take the time to write its tests and refactoring if needed. Otherwise, I'll be maintaining my own fork up to date, cos I find this a very useful tool when working on a team.

I think this could be related to an open issue, but as I'm not sure I'll wait to reference it.