### PR TITLE
fix: also use .prettierignore from current working directory (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,4 +108,4 @@ For example `pretty-quick --since HEAD` will format only staged files.
 
 ## Configuration and Ignore Files
 
-`pretty-quick` will respect your [`.prettierrc`](https://prettier.io/docs/en/configuration), [`.prettierignore`](https://prettier.io/docs/en/ignore#ignoring-files), and [`.editorconfig`](http://editorconfig.org/) files, so there's no additional setup required. Configuration files will be found by searching up the file system. `.prettierignore` files are only found from the working directory that the command was executed from.
+`pretty-quick` will respect your [`.prettierrc`](https://prettier.io/docs/en/configuration), [`.prettierignore`](https://prettier.io/docs/en/ignore#ignoring-files), and [`.editorconfig`](http://editorconfig.org/) files, so there's no additional setup required. Configuration files will be found by searching up the file system. `.prettierignore` files are only found from the repository root and the working directory that the command was executed from.

--- a/src/index.js
+++ b/src/index.js
@@ -29,16 +29,24 @@ export default (
 
   onFoundSinceRevision && onFoundSinceRevision(scm.name, revision);
 
+  const rootIgnorer = createIgnorer(directory);
+  const cwdIgnorer =
+    currentDirectory !== directory
+      ? createIgnorer(currentDirectory)
+      : () => true;
+
   const changedFiles = scm
     .getChangedFiles(directory, revision, staged)
     .filter(isSupportedExtension)
-    .filter(createIgnorer(directory));
+    .filter(rootIgnorer)
+    .filter(cwdIgnorer);
 
   const unstagedFiles = staged
     ? scm
         .getUnstagedChangedFiles(directory, revision)
         .filter(isSupportedExtension)
-        .filter(createIgnorer(directory))
+        .filter(rootIgnorer)
+        .filter(cwdIgnorer)
     : [];
 
   const wasFullyStaged = f => unstagedFiles.indexOf(f) < 0;


### PR DESCRIPTION
This pull request tries to fix #14 with a zero config approach.

If the `process.cwd()` is not the same as the git root it will also try to load the .prettierignore file from there.