### PR TITLE
feat: Add --bail option which fails on fix (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ For example `pretty-quick --pattern "**/*.*(js|jsx)"` or `pretty-quick --pattern
 
 Outputs the name of each file right before it is proccessed. This can be useful if Prettier throws an error and you can't identify which file is causing the problem.
 
+## `--bail`
+
+Prevent `git commit` if any files are fixed.
+
 <!-- Undocumented = Unsupported :D
 
 ### `--config`

--- a/bin/pretty-quick.js
+++ b/bin/pretty-quick.js
@@ -9,8 +9,7 @@ const prettyQuick = require('..').default;
 
 const args = mri(process.argv.slice(2));
 
-let success = true;
-prettyQuick(
+const prettyQuickResult = prettyQuick(
   process.cwd(),
   Object.assign({}, args, {
     onFoundSinceRevision: (scm, revision) => {
@@ -31,7 +30,6 @@ prettyQuick(
 
     onPartiallyStagedFile: file => {
       console.log(`✗ Found ${chalk.bold('partially')} staged file ${file}.`);
-      success = false;
     },
 
     onWriteFile: file => {
@@ -44,12 +42,19 @@ prettyQuick(
   })
 );
 
-if (success) {
+if (prettyQuickResult.success) {
   console.log('✅  Everything is awesome!');
 } else {
-  console.log(
-    '✗ Partially staged files were fixed up.' +
-      ` ${chalk.bold('Please update stage before committing')}.`
-  );
+  if (prettyQuickResult.errors.indexOf('PARTIALLY_STAGED_FILE') !== -1) {
+    console.log(
+      '✗ Partially staged files were fixed up.' +
+        ` ${chalk.bold('Please update stage before committing')}.`
+    );
+  }
+  if (prettyQuickResult.errors.indexOf('BAIL_ON_WRITE') !== -1) {
+    console.log(
+      '✗ File had to be prettified and prettyQuick was set to bail mode.'
+    );
+  }
   process.exit(1); // ensure git hooks abort
 }

--- a/src/__tests__/scm-git.test.js
+++ b/src/__tests__/scm-git.test.js
@@ -212,6 +212,22 @@ describe('with git', () => {
     expect(fs.readFileSync('/bar.md', 'utf8')).toEqual('formatted:# foo');
   });
 
+  test('succeeds if a file was changed and bail is not set', () => {
+    mockGitFs();
+
+    const result = prettyQuick('root', { since: 'banana' });
+
+    expect(result).toEqual({ errors: [], success: true });
+  });
+
+  test('fails if a file was changed and bail is set to true', () => {
+    mockGitFs();
+
+    const result = prettyQuick('root', { since: 'banana', bail: true });
+
+    expect(result).toEqual({ errors: ['BAIL_ON_WRITE'], success: false });
+  });
+
   test('with --staged stages fully-staged files', () => {
     mockGitFs();
 
@@ -252,6 +268,17 @@ describe('with git', () => {
 
     expect(execa.sync).not.toHaveBeenCalledWith('git', ['add', './raz.js'], {
       cwd: '/',
+    });
+  });
+
+  test('with --staged returns false', () => {
+    const additionalUnstaged = './raz.js\n'; // raz.js is partly staged and partly not staged
+    mockGitFs(additionalUnstaged);
+
+    const result = prettyQuick('root', { since: 'banana', staged: true });
+    expect(result).toEqual({
+      errors: ['PARTIALLY_STAGED_FILE'],
+      success: false,
     });
   });
 

--- a/src/__tests__/scm-hg.test.js
+++ b/src/__tests__/scm-hg.test.js
@@ -156,6 +156,22 @@ describe('with hg', () => {
     expect(fs.readFileSync('/bar.md', 'utf8')).toEqual('formatted:# foo');
   });
 
+  test('succeeds if a file was changed and bail is not set', () => {
+    mockHgFs();
+
+    const result = prettyQuick('root', { since: 'banana' });
+
+    expect(result).toEqual({ errors: [], success: true });
+  });
+
+  test('fails if a file was changed and bail is set to true', () => {
+    mockHgFs();
+
+    const result = prettyQuick('root', { since: 'banana', bail: true });
+
+    expect(result).toEqual({ errors: ['BAIL_ON_WRITE'], success: false });
+  });
+
   test('calls onWriteFile with changed files for an array of globstar patterns', () => {
     const onWriteFile = jest.fn();
     mockHgFs();


### PR DESCRIPTION
Based on #53 from @josejulio.

- Moves the success logic into `prettyQuick`
- Added a new error message: `'✗ File had to be prettified and prettyQuick was set to bail mode.'`
- Add unit tests


@azz and @josejulio could you please take a look?