### PR TITLE
 Add “—custom-extensions” option to allow user to prettify files with extensions that are not listed in Prettier supported languages extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,23 @@ Outputs the name of each file right before it is proccessed. This can be useful 
 
 Prevent `git commit` if any files are fixed.
 
+## `--custom-extensions`
+
+If you want to prettify your `.babelrc` or `.eslintrc` files with `json` parser, you can update your `.prettierrc` with
+
+```
+{
+  "overrides": [
+    {
+      "files": ".(eslintrc|babelrc)",
+      "options": { "parser": "json" }
+    }
+  ]
+}
+```
+
+and then run `pretty-quick --custom-extensions=eslintrc,babelrc`
+
 <!-- Undocumented = Unsupported :D
 
 ### `--config`

--- a/bin/pretty-quick.js
+++ b/bin/pretty-quick.js
@@ -12,6 +12,10 @@ const args = mri(process.argv.slice(2));
 const prettyQuickResult = prettyQuick(
   process.cwd(),
   Object.assign({}, args, {
+    customExtensions: args['custom-extensions']
+      ? args['custom-extensions'].split(',')
+      : [],
+
     onFoundSinceRevision: (scm, revision) => {
       console.log(
         `🔍  Finding changed files since ${chalk.bold(

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test": "jest",
     "lint": "eslint . --ignore-path=.gitignore",
     "semantic-release": "semantic-release",
-    "precommit": "./bin/pretty-quick.js --staged"
+    "precommit": "./bin/pretty-quick.js --staged --custom-extensions=babelrc"
   },
   "peerDependencies": {
     "prettier": ">=1.8.0"

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ export default (
     pattern,
     restage = true,
     branch,
-    customExtensions,
+    customExtensions = [],
     bail,
     verbose,
     onFoundSinceRevision,

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ export default (
     pattern,
     restage = true,
     branch,
+    customExtensions,
     bail,
     verbose,
     onFoundSinceRevision,
@@ -38,9 +39,29 @@ export default (
       ? createIgnorer(currentDirectory)
       : () => true;
 
+  const isValidExtension = file => {
+    if (isSupportedExtension(file)) {
+      return true;
+    }
+
+    if (!customExtensions.length) {
+      return false;
+    }
+
+    const dotIndex = file.lastIndexOf('.');
+
+    if (dotIndex === -1 || dotIndex === file.length - 1) {
+      return false;
+    }
+
+    const ext = file.slice(dotIndex + 1);
+
+    return customExtensions.includes(ext);
+  };
+
   const changedFiles = scm
     .getChangedFiles(directory, revision, staged)
-    .filter(isSupportedExtension)
+    .filter(isValidExtension)
     .filter(createMatcher(pattern))
     .filter(rootIgnorer)
     .filter(cwdIgnorer);
@@ -48,7 +69,7 @@ export default (
   const unstagedFiles = staged
     ? scm
         .getUnstagedChangedFiles(directory, revision)
-        .filter(isSupportedExtension)
+        .filter(isValidExtension)
         .filter(createMatcher(pattern))
         .filter(rootIgnorer)
         .filter(cwdIgnorer)


### PR DESCRIPTION
User can specify custom extensions `.eslintrc` or `.babelrc` with `—custom-extensions` option and they should be prettified.

Dot-file extension can’t be matched with `path.extname` util and I added logic to match all characters after last dot in the file path for custom extensions.

README was updated with new option description.

I add `.babelrc` custom extension in `precommit` npm script. You can try to change `.babelrc` file (add extra spaces somewhere) and then commit changes, `.babelrc` will be prettified.