### PR TITLE
feat: add --check CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ Outputs the name of each file right before it is proccessed. This can be useful 
 
 Prevent `git commit` if any files are fixed.
 
+### `--check`
+
+Check that files are correctly formatted, but don't format them. This is useful on CI to verify that all changed files in the current branch were correctly formatted.
+
 <!-- Undocumented = Unsupported :D
 
 ### `--config`

--- a/bin/pretty-quick.js
+++ b/bin/pretty-quick.js
@@ -42,7 +42,7 @@ const prettyQuickResult = prettyQuick(
       }
     },
 
-    onProcessFile: file => {
+    onExamineFile: file => {
       console.log(`🔍  Examining ${chalk.bold(file)}.`);
     },
   })

--- a/bin/pretty-quick.js
+++ b/bin/pretty-quick.js
@@ -32,15 +32,17 @@ const prettyQuickResult = prettyQuick(
       console.log(`✗ Found ${chalk.bold('partially')} staged file ${file}.`);
     },
 
-    onProcessFile: file => {
-      if (args.check) {
-        console.log(`👀  Checking ${chalk.bold(file)}.`);
-      } else {
-        console.log(`✍️  Fixing up ${chalk.bold(file)}.`);
+    onWriteFile: file => {
+      console.log(`✍️  Fixing up ${chalk.bold(file)}.`);
+    },
+
+    onCheckFile: (file, isFormatted) => {
+      if (!isFormatted) {
+        console.log(`⛔️  Check failed: ${chalk.bold(file)}`);
       }
     },
 
-    onExamineFile: file => {
+    onProcessFile: file => {
       console.log(`🔍  Examining ${chalk.bold(file)}.`);
     },
   })

--- a/bin/pretty-quick.js
+++ b/bin/pretty-quick.js
@@ -33,7 +33,11 @@ const prettyQuickResult = prettyQuick(
     },
 
     onProcessFile: file => {
-      console.log(`✍️  Fixing up ${chalk.bold(file)}.`);
+      if (args.check) {
+        console.log(`👀  Checking ${chalk.bold(file)}.`);
+      } else {
+        console.log(`✍️  Fixing up ${chalk.bold(file)}.`);
+      }
     },
 
     onExamineFile: file => {
@@ -54,6 +58,11 @@ if (prettyQuickResult.success) {
   if (prettyQuickResult.errors.indexOf('BAIL_ON_WRITE') !== -1) {
     console.log(
       '✗ File had to be prettified and prettyQuick was set to bail mode.'
+    );
+  }
+  if (prettyQuickResult.errors.indexOf('CHECK_FAILED') !== -1) {
+    console.log(
+      '✗ Code style issues found in the above file(s). Forgot to run Prettier?'
     );
   }
   process.exit(1); // ensure git hooks abort

--- a/bin/pretty-quick.js
+++ b/bin/pretty-quick.js
@@ -32,7 +32,7 @@ const prettyQuickResult = prettyQuick(
       console.log(`✗ Found ${chalk.bold('partially')} staged file ${file}.`);
     },
 
-    onWriteFile: file => {
+    onProcessFile: file => {
       console.log(`✍️  Fixing up ${chalk.bold(file)}.`);
     },
 

--- a/src/__tests__/scm-git.test.js
+++ b/src/__tests__/scm-git.test.js
@@ -150,63 +150,63 @@ describe('with git', () => {
     expect(onFoundChangedFiles).toHaveBeenCalledWith(['./foo.js', './bar.md']);
   });
 
-  test('calls onWriteFile with changed files', () => {
-    const onWriteFile = jest.fn();
+  test('calls onProcessFile with changed files', () => {
+    const onProcessFile = jest.fn();
     mockGitFs();
 
-    prettyQuick('root', { since: 'banana', onWriteFile });
+    prettyQuick('root', { since: 'banana', onProcessFile });
 
-    expect(onWriteFile).toHaveBeenCalledWith('./foo.js');
-    expect(onWriteFile).toHaveBeenCalledWith('./bar.md');
-    expect(onWriteFile.mock.calls.length).toBe(2);
+    expect(onProcessFile).toHaveBeenCalledWith('./foo.js');
+    expect(onProcessFile).toHaveBeenCalledWith('./bar.md');
+    expect(onProcessFile.mock.calls.length).toBe(2);
   });
 
-  test('calls onWriteFile with changed files for the given pattern', () => {
-    const onWriteFile = jest.fn();
+  test('calls onProcessFile with changed files for the given pattern', () => {
+    const onProcessFile = jest.fn();
     mockGitFs();
-    prettyQuick('root', { pattern: '*.md', since: 'banana', onWriteFile });
-    expect(onWriteFile.mock.calls).toEqual([['./bar.md']]);
+    prettyQuick('root', { pattern: '*.md', since: 'banana', onProcessFile });
+    expect(onProcessFile.mock.calls).toEqual([['./bar.md']]);
   });
 
-  test('calls onWriteFile with changed files for the given globstar pattern', () => {
-    const onWriteFile = jest.fn();
+  test('calls onProcessFile with changed files for the given globstar pattern', () => {
+    const onProcessFile = jest.fn();
     mockGitFs();
     prettyQuick('root', {
       pattern: '**/*.md',
       since: 'banana',
-      onWriteFile,
+      onProcessFile,
     });
-    expect(onWriteFile.mock.calls).toEqual([['./bar.md']]);
+    expect(onProcessFile.mock.calls).toEqual([['./bar.md']]);
   });
 
-  test('calls onWriteFile with changed files for the given extglob pattern', () => {
-    const onWriteFile = jest.fn();
+  test('calls onProcessFile with changed files for the given extglob pattern', () => {
+    const onProcessFile = jest.fn();
     mockGitFs();
     prettyQuick('root', {
       pattern: '*.*(md|foo|bar)',
       since: 'banana',
-      onWriteFile,
+      onProcessFile,
     });
-    expect(onWriteFile.mock.calls).toEqual([['./bar.md']]);
+    expect(onProcessFile.mock.calls).toEqual([['./bar.md']]);
   });
 
-  test('calls onWriteFile with changed files for an array of globstar patterns', () => {
-    const onWriteFile = jest.fn();
+  test('calls onProcessFile with changed files for an array of globstar patterns', () => {
+    const onProcessFile = jest.fn();
     mockGitFs();
     prettyQuick('root', {
       pattern: ['**/*.foo', '**/*.md', '**/*.bar'],
       since: 'banana',
-      onWriteFile,
+      onProcessFile,
     });
-    expect(onWriteFile.mock.calls).toEqual([['./bar.md']]);
+    expect(onProcessFile.mock.calls).toEqual([['./bar.md']]);
   });
 
   test('writes formatted files to disk', () => {
-    const onWriteFile = jest.fn();
+    const onProcessFile = jest.fn();
 
     mockGitFs();
 
-    prettyQuick('root', { since: 'banana', onWriteFile });
+    prettyQuick('root', { since: 'banana', onProcessFile });
 
     expect(fs.readFileSync('/foo.js', 'utf8')).toEqual('formatted:foo()');
     expect(fs.readFileSync('/bar.md', 'utf8')).toEqual('formatted:# foo');
@@ -316,20 +316,20 @@ describe('with git', () => {
   });
 
   test('ignore files matching patterns from the repositories root .prettierignore', () => {
-    const onWriteFile = jest.fn();
+    const onProcessFile = jest.fn();
     mockGitFs('', {
       '/.prettierignore': '*.md',
     });
-    prettyQuick('/sub-directory/', { since: 'banana', onWriteFile });
-    expect(onWriteFile.mock.calls).toEqual([['./foo.js']]);
+    prettyQuick('/sub-directory/', { since: 'banana', onProcessFile });
+    expect(onProcessFile.mock.calls).toEqual([['./foo.js']]);
   });
 
   test('ignore files matching patterns from the working directories .prettierignore', () => {
-    const onWriteFile = jest.fn();
+    const onProcessFile = jest.fn();
     mockGitFs('', {
       '/sub-directory/.prettierignore': '*.md',
     });
-    prettyQuick('/sub-directory/', { since: 'banana', onWriteFile });
-    expect(onWriteFile.mock.calls).toEqual([['./foo.js']]);
+    prettyQuick('/sub-directory/', { since: 'banana', onProcessFile });
+    expect(onProcessFile.mock.calls).toEqual([['./foo.js']]);
   });
 });

--- a/src/__tests__/scm-git.test.js
+++ b/src/__tests__/scm-git.test.js
@@ -150,63 +150,63 @@ describe('with git', () => {
     expect(onFoundChangedFiles).toHaveBeenCalledWith(['./foo.js', './bar.md']);
   });
 
-  test('calls onProcessFile with changed files', () => {
-    const onProcessFile = jest.fn();
+  test('calls onWriteFile with changed files', () => {
+    const onWriteFile = jest.fn();
     mockGitFs();
 
-    prettyQuick('root', { since: 'banana', onProcessFile });
+    prettyQuick('root', { since: 'banana', onWriteFile });
 
-    expect(onProcessFile).toHaveBeenCalledWith('./foo.js');
-    expect(onProcessFile).toHaveBeenCalledWith('./bar.md');
-    expect(onProcessFile.mock.calls.length).toBe(2);
+    expect(onWriteFile).toHaveBeenCalledWith('./foo.js');
+    expect(onWriteFile).toHaveBeenCalledWith('./bar.md');
+    expect(onWriteFile.mock.calls.length).toBe(2);
   });
 
-  test('calls onProcessFile with changed files for the given pattern', () => {
-    const onProcessFile = jest.fn();
+  test('calls onWriteFile with changed files for the given pattern', () => {
+    const onWriteFile = jest.fn();
     mockGitFs();
-    prettyQuick('root', { pattern: '*.md', since: 'banana', onProcessFile });
-    expect(onProcessFile.mock.calls).toEqual([['./bar.md']]);
+    prettyQuick('root', { pattern: '*.md', since: 'banana', onWriteFile });
+    expect(onWriteFile.mock.calls).toEqual([['./bar.md']]);
   });
 
-  test('calls onProcessFile with changed files for the given globstar pattern', () => {
-    const onProcessFile = jest.fn();
+  test('calls onWriteFile with changed files for the given globstar pattern', () => {
+    const onWriteFile = jest.fn();
     mockGitFs();
     prettyQuick('root', {
       pattern: '**/*.md',
       since: 'banana',
-      onProcessFile,
+      onWriteFile,
     });
-    expect(onProcessFile.mock.calls).toEqual([['./bar.md']]);
+    expect(onWriteFile.mock.calls).toEqual([['./bar.md']]);
   });
 
-  test('calls onProcessFile with changed files for the given extglob pattern', () => {
-    const onProcessFile = jest.fn();
+  test('calls onWriteFile with changed files for the given extglob pattern', () => {
+    const onWriteFile = jest.fn();
     mockGitFs();
     prettyQuick('root', {
       pattern: '*.*(md|foo|bar)',
       since: 'banana',
-      onProcessFile,
+      onWriteFile,
     });
-    expect(onProcessFile.mock.calls).toEqual([['./bar.md']]);
+    expect(onWriteFile.mock.calls).toEqual([['./bar.md']]);
   });
 
-  test('calls onProcessFile with changed files for an array of globstar patterns', () => {
-    const onProcessFile = jest.fn();
+  test('calls onWriteFile with changed files for an array of globstar patterns', () => {
+    const onWriteFile = jest.fn();
     mockGitFs();
     prettyQuick('root', {
       pattern: ['**/*.foo', '**/*.md', '**/*.bar'],
       since: 'banana',
-      onProcessFile,
+      onWriteFile,
     });
-    expect(onProcessFile.mock.calls).toEqual([['./bar.md']]);
+    expect(onWriteFile.mock.calls).toEqual([['./bar.md']]);
   });
 
   test('writes formatted files to disk', () => {
-    const onProcessFile = jest.fn();
+    const onWriteFile = jest.fn();
 
     mockGitFs();
 
-    prettyQuick('root', { since: 'banana', onProcessFile });
+    prettyQuick('root', { since: 'banana', onWriteFile });
 
     expect(fs.readFileSync('/foo.js', 'utf8')).toEqual('formatted:foo()');
     expect(fs.readFileSync('/bar.md', 'utf8')).toEqual('formatted:# foo');
@@ -295,41 +295,41 @@ describe('with git', () => {
     });
   });
 
-  test('with --verbose calls onExamineFile', () => {
-    const onExamineFile = jest.fn();
+  test('with --verbose calls onProcessFile', () => {
+    const onProcessFile = jest.fn();
     mockGitFs();
 
-    prettyQuick('root', { since: 'banana', verbose: true, onExamineFile });
+    prettyQuick('root', { since: 'banana', verbose: true, onProcessFile });
 
-    expect(onExamineFile).toHaveBeenCalledWith('./foo.js');
-    expect(onExamineFile).toHaveBeenCalledWith('./bar.md');
+    expect(onProcessFile).toHaveBeenCalledWith('./foo.js');
+    expect(onProcessFile).toHaveBeenCalledWith('./bar.md');
   });
 
-  test('without --verbose does NOT call onExamineFile', () => {
-    const onExamineFile = jest.fn();
+  test('without --verbose does NOT call onProcessFile', () => {
+    const onProcessFile = jest.fn();
     mockGitFs();
 
-    prettyQuick('root', { since: 'banana', onExamineFile });
+    prettyQuick('root', { since: 'banana', onProcessFile });
 
-    expect(onExamineFile).not.toHaveBeenCalledWith('./foo.js');
-    expect(onExamineFile).not.toHaveBeenCalledWith('./bar.md');
+    expect(onProcessFile).not.toHaveBeenCalledWith('./foo.js');
+    expect(onProcessFile).not.toHaveBeenCalledWith('./bar.md');
   });
 
   test('ignore files matching patterns from the repositories root .prettierignore', () => {
-    const onProcessFile = jest.fn();
+    const onWriteFile = jest.fn();
     mockGitFs('', {
       '/.prettierignore': '*.md',
     });
-    prettyQuick('/sub-directory/', { since: 'banana', onProcessFile });
-    expect(onProcessFile.mock.calls).toEqual([['./foo.js']]);
+    prettyQuick('/sub-directory/', { since: 'banana', onWriteFile });
+    expect(onWriteFile.mock.calls).toEqual([['./foo.js']]);
   });
 
   test('ignore files matching patterns from the working directories .prettierignore', () => {
-    const onProcessFile = jest.fn();
+    const onWriteFile = jest.fn();
     mockGitFs('', {
       '/sub-directory/.prettierignore': '*.md',
     });
-    prettyQuick('/sub-directory/', { since: 'banana', onProcessFile });
-    expect(onProcessFile.mock.calls).toEqual([['./foo.js']]);
+    prettyQuick('/sub-directory/', { since: 'banana', onWriteFile });
+    expect(onWriteFile.mock.calls).toEqual([['./foo.js']]);
   });
 });

--- a/src/__tests__/scm-git.test.js
+++ b/src/__tests__/scm-git.test.js
@@ -295,24 +295,24 @@ describe('with git', () => {
     });
   });
 
-  test('with --verbose calls onProcessFile', () => {
-    const onProcessFile = jest.fn();
+  test('with --verbose calls onExamineFile', () => {
+    const onExamineFile = jest.fn();
     mockGitFs();
 
-    prettyQuick('root', { since: 'banana', verbose: true, onProcessFile });
+    prettyQuick('root', { since: 'banana', verbose: true, onExamineFile });
 
-    expect(onProcessFile).toHaveBeenCalledWith('./foo.js');
-    expect(onProcessFile).toHaveBeenCalledWith('./bar.md');
+    expect(onExamineFile).toHaveBeenCalledWith('./foo.js');
+    expect(onExamineFile).toHaveBeenCalledWith('./bar.md');
   });
 
-  test('without --verbose does NOT call onProcessFile', () => {
-    const onProcessFile = jest.fn();
+  test('without --verbose does NOT call onExamineFile', () => {
+    const onExamineFile = jest.fn();
     mockGitFs();
 
-    prettyQuick('root', { since: 'banana', onProcessFile });
+    prettyQuick('root', { since: 'banana', onExamineFile });
 
-    expect(onProcessFile).not.toHaveBeenCalledWith('./foo.js');
-    expect(onProcessFile).not.toHaveBeenCalledWith('./bar.md');
+    expect(onExamineFile).not.toHaveBeenCalledWith('./foo.js');
+    expect(onExamineFile).not.toHaveBeenCalledWith('./bar.md');
   });
 
   test('ignore files matching patterns from the repositories root .prettierignore', () => {

--- a/src/__tests__/scm-hg.test.js
+++ b/src/__tests__/scm-hg.test.js
@@ -196,22 +196,22 @@ describe('with hg', () => {
     });
   });
 
-  test('with --verbose calls onProcessFile', () => {
-    const onProcessFile = jest.fn();
+  test('with --verbose calls onExamineFile', () => {
+    const onExamineFile = jest.fn();
     mockHgFs();
-    prettyQuick('root', { since: 'banana', verbose: true, onProcessFile });
+    prettyQuick('root', { since: 'banana', verbose: true, onExamineFile });
 
-    expect(onProcessFile).toHaveBeenCalledWith('./foo.js');
-    expect(onProcessFile).toHaveBeenCalledWith('./bar.md');
+    expect(onExamineFile).toHaveBeenCalledWith('./foo.js');
+    expect(onExamineFile).toHaveBeenCalledWith('./bar.md');
   });
 
-  test('without --verbose does NOT call onProcessFile', () => {
-    const onProcessFile = jest.fn();
+  test('without --verbose does NOT call onExamineFile', () => {
+    const onExamineFile = jest.fn();
     mockHgFs();
-    prettyQuick('root', { since: 'banana', onProcessFile });
+    prettyQuick('root', { since: 'banana', onExamineFile });
 
-    expect(onProcessFile).not.toHaveBeenCalledWith('./foo.js');
-    expect(onProcessFile).not.toHaveBeenCalledWith('./bar.md');
+    expect(onExamineFile).not.toHaveBeenCalledWith('./foo.js');
+    expect(onExamineFile).not.toHaveBeenCalledWith('./bar.md');
   });
 
   test('ignore files matching patterns from the repositories root .prettierignore', () => {

--- a/src/__tests__/scm-hg.test.js
+++ b/src/__tests__/scm-hg.test.js
@@ -106,51 +106,51 @@ describe('with hg', () => {
     expect(onFoundChangedFiles).toHaveBeenCalledWith(['./foo.js', './bar.md']);
   });
 
-  test('calls onProcessFile with changed files', () => {
-    const onProcessFile = jest.fn();
+  test('calls onWriteFile with changed files', () => {
+    const onWriteFile = jest.fn();
     mockHgFs();
 
-    prettyQuick('root', { since: 'banana', onProcessFile });
+    prettyQuick('root', { since: 'banana', onWriteFile });
 
-    expect(onProcessFile).toHaveBeenCalledWith('./foo.js');
-    expect(onProcessFile).toHaveBeenCalledWith('./bar.md');
+    expect(onWriteFile).toHaveBeenCalledWith('./foo.js');
+    expect(onWriteFile).toHaveBeenCalledWith('./bar.md');
   });
 
-  test('calls onProcessFile with changed files for the given pattern', () => {
-    const onProcessFile = jest.fn();
+  test('calls onWriteFile with changed files for the given pattern', () => {
+    const onWriteFile = jest.fn();
     mockHgFs();
-    prettyQuick('root', { pattern: '*.md', since: 'banana', onProcessFile });
-    expect(onProcessFile.mock.calls).toEqual([['./bar.md']]);
+    prettyQuick('root', { pattern: '*.md', since: 'banana', onWriteFile });
+    expect(onWriteFile.mock.calls).toEqual([['./bar.md']]);
   });
 
-  test('calls onProcessFile with changed files for the given globstar pattern', () => {
-    const onProcessFile = jest.fn();
+  test('calls onWriteFile with changed files for the given globstar pattern', () => {
+    const onWriteFile = jest.fn();
     mockHgFs();
     prettyQuick('root', {
       pattern: '**/*.md',
       since: 'banana',
-      onProcessFile,
+      onWriteFile,
     });
-    expect(onProcessFile.mock.calls).toEqual([['./bar.md']]);
+    expect(onWriteFile.mock.calls).toEqual([['./bar.md']]);
   });
 
-  test('calls onProcessFile with changed files for the given extglob pattern', () => {
-    const onProcessFile = jest.fn();
+  test('calls onWriteFile with changed files for the given extglob pattern', () => {
+    const onWriteFile = jest.fn();
     mockHgFs();
     prettyQuick('root', {
       pattern: '*.*(md|foo|bar)',
       since: 'banana',
-      onProcessFile,
+      onWriteFile,
     });
-    expect(onProcessFile.mock.calls).toEqual([['./bar.md']]);
+    expect(onWriteFile.mock.calls).toEqual([['./bar.md']]);
   });
 
   test('writes formatted files to disk', () => {
-    const onProcessFile = jest.fn();
+    const onWriteFile = jest.fn();
 
     mockHgFs();
 
-    prettyQuick('root', { since: 'banana', onProcessFile });
+    prettyQuick('root', { since: 'banana', onWriteFile });
 
     expect(fs.readFileSync('/foo.js', 'utf8')).toEqual('formatted:foo()');
     expect(fs.readFileSync('/bar.md', 'utf8')).toEqual('formatted:# foo');
@@ -172,15 +172,15 @@ describe('with hg', () => {
     expect(result).toEqual({ errors: ['BAIL_ON_WRITE'], success: false });
   });
 
-  test('calls onProcessFile with changed files for an array of globstar patterns', () => {
-    const onProcessFile = jest.fn();
+  test('calls onWriteFile with changed files for an array of globstar patterns', () => {
+    const onWriteFile = jest.fn();
     mockHgFs();
     prettyQuick('root', {
       pattern: ['**/*.foo', '**/*.md', '**/*.bar'],
       since: 'banana',
-      onProcessFile,
+      onWriteFile,
     });
-    expect(onProcessFile.mock.calls).toEqual([['./bar.md']]);
+    expect(onWriteFile.mock.calls).toEqual([['./bar.md']]);
   });
 
   test('without --staged does NOT stage changed files', () => {
@@ -196,39 +196,39 @@ describe('with hg', () => {
     });
   });
 
-  test('with --verbose calls onExamineFile', () => {
-    const onExamineFile = jest.fn();
+  test('with --verbose calls onProcessFile', () => {
+    const onProcessFile = jest.fn();
     mockHgFs();
-    prettyQuick('root', { since: 'banana', verbose: true, onExamineFile });
+    prettyQuick('root', { since: 'banana', verbose: true, onProcessFile });
 
-    expect(onExamineFile).toHaveBeenCalledWith('./foo.js');
-    expect(onExamineFile).toHaveBeenCalledWith('./bar.md');
+    expect(onProcessFile).toHaveBeenCalledWith('./foo.js');
+    expect(onProcessFile).toHaveBeenCalledWith('./bar.md');
   });
 
-  test('without --verbose does NOT call onExamineFile', () => {
-    const onExamineFile = jest.fn();
+  test('without --verbose does NOT call onProcessFile', () => {
+    const onProcessFile = jest.fn();
     mockHgFs();
-    prettyQuick('root', { since: 'banana', onExamineFile });
+    prettyQuick('root', { since: 'banana', onProcessFile });
 
-    expect(onExamineFile).not.toHaveBeenCalledWith('./foo.js');
-    expect(onExamineFile).not.toHaveBeenCalledWith('./bar.md');
+    expect(onProcessFile).not.toHaveBeenCalledWith('./foo.js');
+    expect(onProcessFile).not.toHaveBeenCalledWith('./bar.md');
   });
 
   test('ignore files matching patterns from the repositories root .prettierignore', () => {
-    const onProcessFile = jest.fn();
+    const onWriteFile = jest.fn();
     mockHgFs({
       '/.prettierignore': '*.md',
     });
-    prettyQuick('/sub-directory/', { since: 'banana', onProcessFile });
-    expect(onProcessFile.mock.calls).toEqual([['./foo.js']]);
+    prettyQuick('/sub-directory/', { since: 'banana', onWriteFile });
+    expect(onWriteFile.mock.calls).toEqual([['./foo.js']]);
   });
 
   test('ignore files matching patterns from the working directories .prettierignore', () => {
-    const onProcessFile = jest.fn();
+    const onWriteFile = jest.fn();
     mockHgFs({
       '/sub-directory/.prettierignore': '*.md',
     });
-    prettyQuick('/sub-directory/', { since: 'banana', onProcessFile });
-    expect(onProcessFile.mock.calls).toEqual([['./foo.js']]);
+    prettyQuick('/sub-directory/', { since: 'banana', onWriteFile });
+    expect(onWriteFile.mock.calls).toEqual([['./foo.js']]);
   });
 });

--- a/src/__tests__/scm-hg.test.js
+++ b/src/__tests__/scm-hg.test.js
@@ -106,51 +106,51 @@ describe('with hg', () => {
     expect(onFoundChangedFiles).toHaveBeenCalledWith(['./foo.js', './bar.md']);
   });
 
-  test('calls onWriteFile with changed files', () => {
-    const onWriteFile = jest.fn();
+  test('calls onProcessFile with changed files', () => {
+    const onProcessFile = jest.fn();
     mockHgFs();
 
-    prettyQuick('root', { since: 'banana', onWriteFile });
+    prettyQuick('root', { since: 'banana', onProcessFile });
 
-    expect(onWriteFile).toHaveBeenCalledWith('./foo.js');
-    expect(onWriteFile).toHaveBeenCalledWith('./bar.md');
+    expect(onProcessFile).toHaveBeenCalledWith('./foo.js');
+    expect(onProcessFile).toHaveBeenCalledWith('./bar.md');
   });
 
-  test('calls onWriteFile with changed files for the given pattern', () => {
-    const onWriteFile = jest.fn();
+  test('calls onProcessFile with changed files for the given pattern', () => {
+    const onProcessFile = jest.fn();
     mockHgFs();
-    prettyQuick('root', { pattern: '*.md', since: 'banana', onWriteFile });
-    expect(onWriteFile.mock.calls).toEqual([['./bar.md']]);
+    prettyQuick('root', { pattern: '*.md', since: 'banana', onProcessFile });
+    expect(onProcessFile.mock.calls).toEqual([['./bar.md']]);
   });
 
-  test('calls onWriteFile with changed files for the given globstar pattern', () => {
-    const onWriteFile = jest.fn();
+  test('calls onProcessFile with changed files for the given globstar pattern', () => {
+    const onProcessFile = jest.fn();
     mockHgFs();
     prettyQuick('root', {
       pattern: '**/*.md',
       since: 'banana',
-      onWriteFile,
+      onProcessFile,
     });
-    expect(onWriteFile.mock.calls).toEqual([['./bar.md']]);
+    expect(onProcessFile.mock.calls).toEqual([['./bar.md']]);
   });
 
-  test('calls onWriteFile with changed files for the given extglob pattern', () => {
-    const onWriteFile = jest.fn();
+  test('calls onProcessFile with changed files for the given extglob pattern', () => {
+    const onProcessFile = jest.fn();
     mockHgFs();
     prettyQuick('root', {
       pattern: '*.*(md|foo|bar)',
       since: 'banana',
-      onWriteFile,
+      onProcessFile,
     });
-    expect(onWriteFile.mock.calls).toEqual([['./bar.md']]);
+    expect(onProcessFile.mock.calls).toEqual([['./bar.md']]);
   });
 
   test('writes formatted files to disk', () => {
-    const onWriteFile = jest.fn();
+    const onProcessFile = jest.fn();
 
     mockHgFs();
 
-    prettyQuick('root', { since: 'banana', onWriteFile });
+    prettyQuick('root', { since: 'banana', onProcessFile });
 
     expect(fs.readFileSync('/foo.js', 'utf8')).toEqual('formatted:foo()');
     expect(fs.readFileSync('/bar.md', 'utf8')).toEqual('formatted:# foo');
@@ -172,15 +172,15 @@ describe('with hg', () => {
     expect(result).toEqual({ errors: ['BAIL_ON_WRITE'], success: false });
   });
 
-  test('calls onWriteFile with changed files for an array of globstar patterns', () => {
-    const onWriteFile = jest.fn();
+  test('calls onProcessFile with changed files for an array of globstar patterns', () => {
+    const onProcessFile = jest.fn();
     mockHgFs();
     prettyQuick('root', {
       pattern: ['**/*.foo', '**/*.md', '**/*.bar'],
       since: 'banana',
-      onWriteFile,
+      onProcessFile,
     });
-    expect(onWriteFile.mock.calls).toEqual([['./bar.md']]);
+    expect(onProcessFile.mock.calls).toEqual([['./bar.md']]);
   });
 
   test('without --staged does NOT stage changed files', () => {
@@ -215,20 +215,20 @@ describe('with hg', () => {
   });
 
   test('ignore files matching patterns from the repositories root .prettierignore', () => {
-    const onWriteFile = jest.fn();
+    const onProcessFile = jest.fn();
     mockHgFs({
       '/.prettierignore': '*.md',
     });
-    prettyQuick('/sub-directory/', { since: 'banana', onWriteFile });
-    expect(onWriteFile.mock.calls).toEqual([['./foo.js']]);
+    prettyQuick('/sub-directory/', { since: 'banana', onProcessFile });
+    expect(onProcessFile.mock.calls).toEqual([['./foo.js']]);
   });
 
   test('ignore files matching patterns from the working directories .prettierignore', () => {
-    const onWriteFile = jest.fn();
+    const onProcessFile = jest.fn();
     mockHgFs({
       '/sub-directory/.prettierignore': '*.md',
     });
-    prettyQuick('/sub-directory/', { since: 'banana', onWriteFile });
-    expect(onWriteFile.mock.calls).toEqual([['./foo.js']]);
+    prettyQuick('/sub-directory/', { since: 'banana', onProcessFile });
+    expect(onProcessFile.mock.calls).toEqual([['./foo.js']]);
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ export default (
     restage = true,
     branch,
     bail,
+    check,
     verbose,
     onFoundSinceRevision,
     onFoundChangedFiles,
@@ -61,9 +62,14 @@ export default (
   const failReasons = new Set();
 
   processFiles(directory, changedFiles, {
+    check,
     config,
     onProcessFile: file => {
       onProcessFile && onProcessFile(file);
+      if (check) {
+        failReasons.add('CHECK_FAILED');
+        return;
+      }
       if (bail) {
         failReasons.add('BAIL_ON_WRITE');
       }

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,8 @@ export default (
     onFoundChangedFiles,
     onPartiallyStagedFile,
     onProcessFile,
-    onExamineFile,
+    onCheckFile,
+    onWriteFile,
   } = {}
 ) => {
   const scm = scms(currentDirectory);
@@ -64,12 +65,8 @@ export default (
   processFiles(directory, changedFiles, {
     check,
     config,
-    onProcessFile: file => {
-      onProcessFile && onProcessFile(file);
-      if (check) {
-        failReasons.add('CHECK_FAILED');
-        return;
-      }
+    onWriteFile: file => {
+      onWriteFile && onWriteFile(file);
       if (bail) {
         failReasons.add('BAIL_ON_WRITE');
       }
@@ -82,7 +79,13 @@ export default (
         }
       }
     },
-    onExamineFile: verbose && onExamineFile,
+    onCheckFile: (file, isFormatted) => {
+      onCheckFile && onCheckFile(file, isFormatted);
+      if (!isFormatted) {
+        failReasons.add('CHECK_FAILED');
+      }
+    },
+    onProcessFile: verbose && onProcessFile,
   });
 
   return {

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ export default (
     onFoundSinceRevision,
     onFoundChangedFiles,
     onPartiallyStagedFile,
-    onProcessFile,
+    onExamineFile,
     onCheckFile,
     onWriteFile,
   } = {}
@@ -85,7 +85,7 @@ export default (
         failReasons.add('CHECK_FAILED');
       }
     },
-    onProcessFile: verbose && onProcessFile,
+    onExamineFile: verbose && onExamineFile,
   });
 
   return {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import scms from './scms';
-import formatFiles from './formatFiles';
+import processFiles from './processFiles';
 import createIgnorer from './createIgnorer';
 import createMatcher from './createMatcher';
 import isSupportedExtension from './isSupportedExtension';
@@ -18,7 +18,7 @@ export default (
     onFoundSinceRevision,
     onFoundChangedFiles,
     onPartiallyStagedFile,
-    onWriteFile,
+    onProcessFile,
     onExamineFile,
   } = {}
 ) => {
@@ -60,10 +60,10 @@ export default (
 
   const failReasons = new Set();
 
-  formatFiles(directory, changedFiles, {
+  processFiles(directory, changedFiles, {
     config,
-    onWriteFile: file => {
-      onWriteFile && onWriteFile(file);
+    onProcessFile: file => {
+      onProcessFile && onProcessFile(file);
       if (bail) {
         failReasons.add('BAIL_ON_WRITE');
       }

--- a/src/processFiles.js
+++ b/src/processFiles.js
@@ -5,7 +5,7 @@ import { join } from 'path';
 export default (
   directory,
   files,
-  { config, onWriteFile, onExamineFile } = {}
+  { config, onProcessFile, onExamineFile } = {}
 ) => {
   for (const relative of files) {
     onExamineFile && onExamineFile(relative);
@@ -21,7 +21,7 @@ export default (
 
     if (output !== input) {
       writeFileSync(file, output);
-      onWriteFile && onWriteFile(relative);
+      onProcessFile && onProcessFile(relative);
     }
   }
 };

--- a/src/processFiles.js
+++ b/src/processFiles.js
@@ -5,10 +5,10 @@ import { join } from 'path';
 export default (
   directory,
   files,
-  { check, config, onProcessFile, onExamineFile } = {}
+  { check, config, onProcessFile, onCheckFile, onWriteFile } = {}
 ) => {
   for (const relative of files) {
-    onExamineFile && onExamineFile(relative);
+    onProcessFile && onProcessFile(relative);
     const file = join(directory, relative);
     const options = Object.assign(
       {},
@@ -20,16 +20,17 @@ export default (
     );
     const input = readFileSync(file, 'utf8');
 
-    if (check && !prettier.check(input, options)) {
-      onProcessFile && onProcessFile(relative);
-      return;
+    if (check) {
+      const isFormatted = prettier.check(input, options);
+      onCheckFile && onCheckFile(relative, isFormatted);
+      continue;
     }
 
     const output = prettier.format(input, options);
 
     if (output !== input) {
       writeFileSync(file, output);
-      onProcessFile && onProcessFile(relative);
+      onWriteFile && onWriteFile(relative);
     }
   }
 };

--- a/src/processFiles.js
+++ b/src/processFiles.js
@@ -5,10 +5,10 @@ import { join } from 'path';
 export default (
   directory,
   files,
-  { check, config, onProcessFile, onCheckFile, onWriteFile } = {}
+  { check, config, onExamineFile, onCheckFile, onWriteFile } = {}
 ) => {
   for (const relative of files) {
-    onProcessFile && onProcessFile(relative);
+    onExamineFile && onExamineFile(relative);
     const file = join(directory, relative);
     const options = Object.assign(
       {},


### PR DESCRIPTION
My use case: I want to run `prettier --check` on CI, but in order to speed up my CI tasks, I'd rather not check every file in my codebase on every commit. Ideally I'd like to be able to run `prettier --check`, but just on the files changed in the current branch.

This is really similar to what `pretty-quick --bail` does, but I don't actually want to format the files, I just want pretty-quick to tell me if they need formatting.

This PR adds a `--check` CLI flag that runs [`prettier.check`](https://prettier.io/docs/en/api.html#prettierchecksource-options) instead of `prettier.format` and exits with a non-zero status code if any files fail the check.

I also renamed `onWriteFile` to `onProcessFile` and `formatFiles.js` to `processFiles.js` to reflect that they now handle either formatting _or_ checking operations. This change is in a separate commit to keep the diff for the [main code change](https://github.com/azz/pretty-quick/commit/d4e9f762cb7daf2f73aff3dae78f5469b849c939) a bit cleaner.