### PR TITLE
Fix `.js.flow` bug

### DIFF
--- a/src/isSupportedExtension.js
+++ b/src/isSupportedExtension.js
@@ -5,4 +5,4 @@ const extensions = getSupportInfo().languages.reduce(
   [],
 );
 
-export default file => extensions.some((ext) => file.endsWith(ext));
+export default file => extensions.some(ext => file.endsWith(ext));

--- a/src/isSupportedExtension.js
+++ b/src/isSupportedExtension.js
@@ -1,4 +1,3 @@
-import { extname } from 'path';
 import { getSupportInfo } from 'prettier';
 
 const extensions = getSupportInfo().languages.reduce(
@@ -6,4 +5,4 @@ const extensions = getSupportInfo().languages.reduce(
   [],
 );
 
-export default file => extensions.includes(extname(file));
+export default file => extensions.some((ext) => file.endsWith(ext));


### PR DESCRIPTION
Extensions can contain '.js.flow' but `extname` only returns the last one, so it never matches.

https://github.com/prettier/prettier/blob/ef880ec4b93230ac1c45be830ff060e78e0740d8/src/language-js/index.js#L22
https://nodejs.org/api/path.html#path_path_extname_path