### PR TITLE
fix: don't copy tests on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "prepublishOnly": "yarn build",
     "pretty-quick": "./bin/pretty-quick.js",
-    "build": "babel src -d dist --copy-files --ignore __tests__",
+    "build": "babel src -d dist --copy-files --no-copy-ignored --ignore '**/__tests__/*.js'",
     "test": "jest",
     "lint": "eslint . --ignore-path=.gitignore",
     "semantic-release": "semantic-release"


### PR DESCRIPTION
I noticed in working on my other PR that all the tests were being run twice when I executed `npm run test`, once for src/ folder and once for dist/ folder. I noticed the build command was set to ignore the tests but it was still copying them. An additional parameter and an updated pattern were required to properly ignore the tests. Babel cli docs: https://babeljs.io/docs/en/babel-cli#ignore-files

Alternatively, if we want the tests in /dist, could we configure jest to ignore /dist? 