### PR TITLE
feat:Bump the version of prettier and related prettier libraries to support typescript 4.3 new syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "prettier": "@azz/prettier-config",
   "peerDependencies": {
-    "prettier": ">=2.0.0"
+    "prettier": ">=2.3.1"
   },
   "devDependencies": {
     "@azz/prettier-config": "^1.0.0",
@@ -63,6 +63,6 @@
     "husky": "^4.2.3",
     "jest": "^25.2.3",
     "mock-fs": "^4.11.0",
-    "prettier": "2.0.2"
+    "prettier": "2.3.1"
   }
 }


### PR DESCRIPTION
The current prettier it depends on its the `prettier 2.0.2`

The latest version of the prettier 2.3.1 has solved the problem and support typescript 4.3
https://github.com/prettier/prettier/issues/10642

It would be good to have it support in the pretty-quick package instead of having it installed the prettier package again. 

It will unblock the user who are trying to use pretty-quick with typescript 4.3