### PR TITLE
fix: check for supportedExtensions after filtering ignored files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,10 +44,10 @@ export default (
 
   const changedFiles = scm
     .getChangedFiles(directory, revision, staged)
-    .filter(isSupportedExtension(resolveConfig))
     .filter(createMatcher(pattern))
     .filter(rootIgnorer)
-    .filter(cwdIgnorer);
+    .filter(cwdIgnorer)
+    .filter(isSupportedExtension(resolveConfig));
 
   const unstagedFiles = staged
     ? scm


### PR DESCRIPTION
If there are any staged files in directory containing a `package.json` (it doesn't need to be changed/staged), even if the directory is meant to be ignored, the function `isSupportedExtension()` is run. This can fail if the `package.json` file has invalid JSON for example (`resolveConfig` from prettier actually fails). Moving the filters around so that the ignored files are properly accounted for gets rid of the error. 

I'm not sure if the unstaged files need to be filtered the same way: https://github.com/azz/pretty-quick/blob/f11faa91d5c570407c37ed77ac04ec0f5e0ef64e/src/index.js#L52-L59

Example repository to test this: https://github.com/ullasholla/pretty-quick-ignore-test
The `templates` directory contain [ejs](https://ejs.co/) templates and the `.json` files are not yet valid JSON files.

To test, make a change to `templates/core/config.json` and stage it.

Tests are passing locally:
![image](https://user-images.githubusercontent.com/212316/141191927-042a49a5-8e68-42f0-9cdf-8b1b3a851056.png)

Could you please review and consider merging this?

Thanks!
